### PR TITLE
Added scrolltop for result page navigation #15

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -61,10 +61,12 @@
       $olderPage.click(function () {
         currentPage++;
         $(historyModel).trigger('modelrefresh');
+        $('#div-main').animate({scrollTop:$('#div-main').position().top}, 'slow');
       });
       $newerPage.click(function () {
         if (currentPage !== 0) currentPage--;
         $(historyModel).trigger('modelrefresh');
+        $('#div-main').animate({scrollTop:$('#div-main').position().top}, 'slow');
       });
       // Navigation controls disabled onload
       $allNav.attr('disabled', true);

--- a/lib/view.js
+++ b/lib/view.js
@@ -16,7 +16,7 @@
   // @exports historyView
   this.historyView = (function () {
     // Initial DOM (jQuery) variables
-    var $table, $olderPage, $newerPage, $allNav, $throbber, $pageNo;
+    var $table, $olderPage, $newerPage, $allNav, $throbber, $pageNo, $divMain;
     // Current page in the history view
     var currentPage = 0;
 
@@ -57,16 +57,23 @@
       $allNav = $olderPage.add($newerPage);
       $throbber = $('#throbber');
       $pageNo = $('.page-no');
+	  // Scroll to top of results
+      function navTop(){
+        $divMain = $('#div-main');
+        $divMain.animate({
+            scrollTop: $divMain.position().top
+        }, 'slow');
+      }
       // Bind buttons functionalities
       $olderPage.click(function () {
         currentPage++;
         $(historyModel).trigger('modelrefresh');
-        $('#div-main').animate({scrollTop:$('#div-main').position().top}, 'slow');
+        navTop();
       });
       $newerPage.click(function () {
         if (currentPage !== 0) currentPage--;
         $(historyModel).trigger('modelrefresh');
-        $('#div-main').animate({scrollTop:$('#div-main').position().top}, 'slow');
+        navTop();
       });
       // Navigation controls disabled onload
       $allNav.attr('disabled', true);

--- a/lib/view.js
+++ b/lib/view.js
@@ -57,11 +57,12 @@
       $allNav = $olderPage.add($newerPage);
       $throbber = $('#throbber');
       $pageNo = $('.page-no');
-	  // Scroll to top of results
+      // Division that holds the scroll value for the overflow
+      $divMain = $('#div-main');
+      // Scroll to top of results
       function navTop(){
-        $divMain = $('#div-main');
         $divMain.animate({
-            scrollTop: $divMain.position().top
+          scrollTop: $divMain.position().top
         }, 'slow');
       }
       // Bind buttons functionalities


### PR DESCRIPTION
Took me longer than it should have to realize the scroll was on div-main.

Added animate because normal scrolling didn't feel natural. Though it's useless when the page doesn't quickly load or isn't preloaded, the throbber.

Edit: I can just use normal scrolltop if you think this affects the performance, I don't think it should though.
